### PR TITLE
Rework how SSH and API keys are set

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ duffy_app_version: 3.0.0a6
 
 duffy_admin_tenant: admin
 duffy_admin_api_key: "please override this in production"
-duffy_admin_ssh_key: "please override this in production"
+duffy_admin_ssh_key: "# please override this in production"
 
 duffy_python_executable: python3
 duffy_python_pkgs:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -189,15 +189,20 @@
           changed_when: admin_tenant_exists.rc == 0
 
         - name: Create admin tenant
-          command: "duffy tenant create --is-admin {{ duffy_admin_tenant }}"
+          command:
+            argv:
+              - duffy
+              - tenant
+              - create
+              - --is-admin
+              - --ssh-key
+              - "{{ duffy_admin_ssh_key }}"
+              - "{{ duffy_admin_tenant }}"
           when: admin_tenant_exists.rc != 0
 
         - name: Set API key of admin tenant
           command: >-
             duffy tenant update {{ duffy_admin_tenant }} --api-key {{ duffy_admin_api_key }}
-          when: "duffy_admin_api_key != 'please override this in production'"
-
-        - name: Set SSH key of admin tenant
-          command: >-
-            duffy tenant update {{ duffy_admin_tenant }} --ssh-key {{ duffy_admin_ssh_key }}
-          when: "duffy_admin_ssh_key != 'please override this in production'"
+          when: >-
+            admin_tenant_exists.rc != 0
+            and duffy_admin_api_key != "please override this in production"


### PR DESCRIPTION
Rework how SSH and API keys are set
    
- Set SSH key when creating `admin` tenant.
- Only set API key if `admin` tenant is created.
    
Signed-off-by: Nils Philippsen <nils@redhat.com>