### PR TITLE
Update to version 3.1.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Defaults variables for the duffy role
 
-duffy_app_version: 3.0.1
+duffy_app_version: 3.1.0
 
 duffy_admin_tenant: admin
 duffy_admin_api_key: "please override this in production"  # one can use `uuidgen` for this

--- a/templates/systemd/duffy-app.service.j2
+++ b/templates/systemd/duffy-app.service.j2
@@ -6,7 +6,7 @@ Requires=duffy-tasks.service
 User=duffy
 Group=duffy
 EnvironmentFile=-/etc/sysconfig/duffy
-ExecStart={{ duffy_venv }}/bin/duffy $DUFFY_OPTS serve $DUFFY_APP_OPTS
+ExecStart={{ duffy_venv }}/bin/duffy $DUFFY_GLOBAL_OPTS $DUFFY_APP_GLOBAL_OPTS serve $DUFFY_APP_OPTS
 
 [Install]
 WantedBy=default.target

--- a/templates/systemd/duffy-metaclient.service.j2
+++ b/templates/systemd/duffy-metaclient.service.j2
@@ -6,7 +6,7 @@ Requires=duffy-app.service
 User=duffy
 Group=duffy
 EnvironmentFile=-/etc/sysconfig/duffy
-ExecStart={{ duffy_venv }}/bin/duffy $DUFFY_OPTS serve-legacy $DUFFY_METACLIENT_OPTS
+ExecStart={{ duffy_venv }}/bin/duffy $DUFFY_GLOBAL_OPTS $DUFFY_METACLIENT_GLOBAL_OPTS serve-legacy $DUFFY_METACLIENT_OPTS
 
 [Install]
 WantedBy=default.target

--- a/templates/systemd/duffy-tasks.service.j2
+++ b/templates/systemd/duffy-tasks.service.j2
@@ -5,7 +5,7 @@ After=network.target
 User=duffy
 Group=duffy
 EnvironmentFile=-/etc/sysconfig/duffy
-ExecStart={{ duffy_venv }}/bin/duffy $DUFFY_OPTS worker -B --schedule-filename {{ duffy_tasks_schedule_filename }} $DUFFY_TASKS_OPTS
+ExecStart={{ duffy_venv }}/bin/duffy $DUFFY_GLOBAL_OPTS $DUFFY_TASKS_GLOBAL_OPTS worker -B --schedule-filename {{ duffy_tasks_schedule_filename }} $DUFFY_TASKS_OPTS
 
 [Install]
 WantedBy=default.target

--- a/templates/systemd/duffy.sysconfig.j2
+++ b/templates/systemd/duffy.sysconfig.j2
@@ -1,5 +1,8 @@
 # Set additional command line parameters for Duffy services
-DUFFY_OPTS=
-DUFFY_APP_OPTS=--loglevel={{ duffy_app_loglevel }}
-DUFFY_METACLIENT_OPTS=--loglevel={{ duffy_metaclient_loglevel }}
-DUFFY_TASKS_OPTS=--loglevel={{ duffy_tasks_loglevel }} --concurrency={{ duffy_tasks_concurrency }}
+DUFFY_GLOBAL_OPTS=
+DUFFY_APP_GLOBAL_OPTS=--loglevel={{ duffy_app_loglevel }}
+DUFFY_APP_OPTS=
+DUFFY_METACLIENT_GLOBAL_OPTS=--loglevel={{ duffy_metaclient_loglevel }}
+DUFFY_METACLIENT_OPTS=
+DUFFY_TASKS_GLOBAL_OPTS=--loglevel={{ duffy_tasks_loglevel }}
+DUFFY_TASKS_OPTS=--concurrency={{ duffy_tasks_concurrency }}


### PR DESCRIPTION
This makes --loglevel a global option (again) which, thanks to click,
must be in a specific place on the command line.

Signed-off-by: Nils Philippsen <nils@redhat.com>