### PR TITLE
Add client configuration for the `duffy` Unix user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ duffy_dev_pkgs:
   - libpq-devel
 duffy_venv: /var/lib/duffy/venv
 duffy_tasks_schedule_filename: /var/lib/duffy/celerybeat-schedule
-duffy_config_files:
+duffy_system_config_files:
   - 10_app
   - 20_metaclient
   - 30_logging
@@ -28,9 +28,11 @@ duffy_config_files:
   # Node pool configuration is installed from {{ filestore }}/duffy
   # - 70_nodepools
   - 80_secrets
+duffy_user_config_files:
+  - 00_client
 
 # Obsolete configuration files which should be removed
-duffy_config_files_remove:
+duffy_system_config_files_remove:
   - 60_misc
 
 # Some files will be distributed from {{ filestore }}/duffy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,9 +87,17 @@
             follow: no
             mode: u=rwx,go=rx
 
-    - name: Create Duffy configuration directory
+    - name: Create Duffy system configuration directory
       file:
         path: /etc/duffy
+        state: directory
+      tags:
+        - files
+
+    - name: Create Duffy user configuration directory
+      become_user: duffy
+      file:
+        path: /home/duffy/.config/duffy
         state: directory
       tags:
         - files
@@ -109,14 +117,14 @@
         - config
         - files
       block:
-        - name: Install templated Duffy configuration files
+        - name: Install templated Duffy system configuration files
           template:
             src: "config/{{ item }}.yaml.j2"
             dest: "/etc/duffy/{{ item }}.yaml"
             owner: root
             group: duffy
             mode: "u=rw,g=r,o={{ ('secret' in item) | ternary('', 'r') }}"
-          loop: "{{ duffy_config_files }}"
+          loop: "{{ duffy_system_config_files }}"
 
         - name: Install Duffy node pool configuration
           copy:
@@ -126,11 +134,22 @@
             group: duffy
             mode: "u=rw,go=r"
 
-        - name: Remove obsolete configuration files
+        - name: Remove obsolete system configuration files
           file:
             path: "/etc/duffy/{{ item }}.yaml"
             state: absent
-          loop: "{{ duffy_config_files_remove }}"
+          loop: "{{ duffy_system_config_files_remove }}"
+
+        - name: Install templated Duffy user configuration files
+          become_user: duffy
+          template:
+            src: "config/{{ item }}.yaml.j2"
+            dest: "/home/duffy/.config/duffy/{{ item }}.yaml"
+            owner: duffy
+            group: duffy
+            # protect auth credentials
+            mode: "u=rw,go="
+          loop: "{{ duffy_user_config_files }}"
 
     - become_user: duffy
       tags:

--- a/templates/config/00_client.yaml.j2
+++ b/templates/config/00_client.yaml.j2
@@ -1,0 +1,6 @@
+---
+client:
+  url: http://{{ duffy_app_host }}:{{ duffy_app_port }}/api/v1
+  auth:
+    name: {{ duffy_admin_tenant }}
+    key: {{ duffy_admin_key }}


### PR DESCRIPTION
This change distinguishes between system and user configuration files,
which end up in /etc/duffy and /home/duffy/.config/duffy, respectively.

Signed-off-by: Nils Philippsen <nils@redhat.com>