### PR TITLE
Update to version 3.3.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Defaults variables for the duffy role
 
-duffy_app_version: 3.2.1
+duffy_app_version: 3.3.0
 
 duffy_admin_tenant: admin
 duffy_admin_api_key: "please override this in production"  # one can use `uuidgen` for this

--- a/templates/config/30_logging.yaml.j2
+++ b/templates/config/30_logging.yaml.j2
@@ -2,81 +2,9 @@
 app:
   logging:
     version: 1
-    disable_existing_loggers: false
-    formatters:
-      default:
-        (): uvicorn.logging.DefaultFormatter
-        fmt: '%(levelprefix)s %(message)s'
-        use_colors: null
-      access:
-        (): uvicorn.logging.AccessFormatter
-        fmt: '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
-    handlers:
-      default:
-        class: logging.StreamHandler
-        formatter: default
-        stream: ext://sys.stderr
-      access:
-        class: logging.StreamHandler
-        formatter: access
-        stream: ext://sys.stdout
-      syslog:
-        class: logging.handlers.SysLogHandler
-        address: /dev/log
-    loggers:
-      duffy:
-        handlers:
-        - default
-        - syslog
-      uvicorn:
-        handlers:
-        - default
-        level: INFO
-      uvicorn.error:
-        level: INFO
-      uvicorn.access:
-        handlers:
-        - access
-        level: INFO
-        propagate: false
+    # Optional Python standard logging section ...
 
 metaclient:
   logging:
     version: 1
-    disable_existing_loggers: false
-    formatters:
-      default:
-        (): uvicorn.logging.DefaultFormatter
-        fmt: '%(levelprefix)s %(message)s'
-        use_colors: null
-      access:
-        (): uvicorn.logging.AccessFormatter
-        fmt: '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
-    handlers:
-      default:
-        class: logging.StreamHandler
-        formatter: default
-        stream: ext://sys.stderr
-      access:
-        class: logging.StreamHandler
-        formatter: access
-        stream: ext://sys.stdout
-      syslog:
-        class: logging.handlers.SysLogHandler
-        address: /dev/log
-    loggers:
-      duffy:
-        handlers:
-        - default
-        - syslog
-      uvicorn:
-        handlers:
-        - default
-        level: INFO
-      uvicorn.error:
-        level: INFO
-      uvicorn.access:
-        handlers:
-        - access
-        level: INFO
-        propagate: false
+    # Optional Python standard logging section ...


### PR DESCRIPTION
This removes most of the logging configuration, which we didn’t really
use. It referenced uvicorn logging formatter classes which have been
moved to a private module in the latest versions and shouldn’t be used
by consumers of uvicorn.

Signed-off-by: Nils Philippsen <nils@redhat.com>