### PR TITLE
Add script to remove a pool from the DB

### DIFF
--- a/files/remove-pool.sh
+++ b/files/remove-pool.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# To be run after removing a pool from Duffy's config
+
+# This will remove all history of the pool from Duffy's DB, which will then
+# mean Zabbix will stop trying to monitor the old pool
+
+pool=$1
+
+if [ -z $pool ] ; then
+  echo "Usage: remove-pool.sh POOL_NAME"
+  exit 1
+fi
+
+psql -U duffy duffy -e -c "DELETE FROM sessions_nodes WHERE pool='$pool' ;"
+psql -U duffy duffy -e -c "DELETE FROM sessions WHERE data->'nodes_specs'->0->>'pool'='$pool' ;"
+psql -U duffy duffy -e -c "DELETE FROM nodes WHERE pool='$pool' ;"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,6 +87,14 @@
             follow: no
             mode: u=rwx,go=rx
 
+        - name: Install the pool cleanup script
+          copy:
+            src: "remove-pool.sh"
+            dest: "/home/duffy/bin/remove-pool.sh"
+            owner: duffy
+            group: duffy
+            mode: u=rwx,go=rx
+
     - name: Create Duffy configuration directory
       file:
         path: /etc/duffy


### PR DESCRIPTION
Per https://pagure.io/centos-infra/issue/1647, this is a script to be run (manually) when we remove a pool from use in Duffy.

I tested on a copy of the db, running in a Postgres 16 container on my laptop:
```
[greg]$ bash ./files/remove-pool.sh virt-ec2-t2-centos-10s-x86_64
DELETE FROM sessions_nodes WHERE pool='virt-ec2-t2-centos-10s-x86_64' ;
DELETE 13
DELETE FROM sessions WHERE data->'nodes_specs'->0->>'pool'='virt-ec2-t2-centos-10s-x86_64' ;
DELETE 7
DELETE FROM nodes WHERE pool='virt-ec2-t2-centos-10s-x86_64' ;
DELETE 11
```

@nphilipp I think it's only these tables, yes?